### PR TITLE
Add Direct Connect Smart Light Strip (16ft) device entry

### DIFF
--- a/src/cync/device-catalog.ts
+++ b/src/cync/device-catalog.ts
@@ -60,6 +60,19 @@ export const DEVICE_CATALOG: Record<number, CyncDeviceModel> = {
 			supportsCt: false,
 		},
 	},
+	110: {
+		deviceType: 110,
+		modelName: 'Direct Connect Strip - Thin Style (16ft)',
+		marketingName: 'Direct Connect Smart Light Strip',
+		defaultCategory: Categories.LIGHTBULB,
+		notes: 'Full color light strip; cloud payload lacks color/level fields, so prefer LAN capability/state detection.',
+		defaultCapabilities: {
+			isLight: true,
+			supportsBrightness: true,
+			supportsColor: true,
+			supportsCt: true,
+		},
+	},
 	123: {
 		deviceType: 123,
 		modelName: 'Direct Connect Strip - Thin Style (32ft)',


### PR DESCRIPTION
This pull request adds a new device catalog entry for the Direct Connect Smart Light Strip (16ft).

The catalog already includes an entry for the 32ft thin-style Direct Connect strip (device type 123), but the 16ft variant was not defined. This change adds device type 110 with matching capabilities.