### PR TITLE
Route BT-only bulbs via Wi-Fi controller in same mesh

### DIFF
--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -492,7 +492,20 @@ export class TcpClient {
 
 	private getControllerCandidates(deviceId: string, primaryControllerId: number): number[] {
 		const preferred = this.preferredControllerByDevice.get(deviceId);
-		const homeId = this.switchIdToHomeId.get(primaryControllerId);
+		let homeId = this.switchIdToHomeId.get(primaryControllerId);
+
+		// Fall back to locating the home via this device's membership.
+		// BT-only bulbs come back from the cloud with switchID=0 and need
+		// to be routed through any Wi-Fi controller in the same mesh.
+		if (!homeId) {
+			for (const [hId, devices] of Object.entries(this.homeDevices)) {
+				if (devices.includes(deviceId)) {
+					homeId = hId;
+					break;
+				}
+			}
+		}
+
 		if (!homeId) {
 			return [primaryControllerId];
 		}

--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -491,37 +491,54 @@ export class TcpClient {
 	}
 
 	private getControllerCandidates(deviceId: string, primaryControllerId: number): number[] {
-		const preferred = this.preferredControllerByDevice.get(deviceId);
-		let homeId = this.switchIdToHomeId.get(primaryControllerId);
+	const preferred = this.preferredControllerByDevice.get(deviceId);
 
-		// Fall back to locating the home via this device's membership.
-		// BT-only bulbs come back from the cloud with switchID=0 and need
-		// to be routed through any Wi-Fi controller in the same mesh.
-		if (!homeId) {
-			for (const [hId, devices] of Object.entries(this.homeDevices)) {
-				if (devices.includes(deviceId)) {
-					homeId = hId;
-					break;
-				}
+	let homeId = this.switchIdToHomeId.get(primaryControllerId);
+
+	if (!homeId) {
+		for (const [candidateHomeId, devices] of Object.entries(this.homeDevices)) {
+			if (devices.includes(deviceId)) {
+				homeId = candidateHomeId;
+				break;
 			}
 		}
-
-		if (!homeId) {
-			return [primaryControllerId];
-		}
-
-		const controllers = [...this.switchIdToHomeId.entries()]
-			.filter(([, candidateHomeId]) => candidateHomeId === homeId)
-			.map(([controllerId]) => controllerId);
-
-		const ordered = [
-			preferred,
-			primaryControllerId,
-			...controllers,
-		].filter((controllerId): controllerId is number => controllerId !== undefined);
-
-		return [...new Set(ordered)];
 	}
+
+	if (!homeId && primaryControllerId === 0 && this.switchIdToHomeId.size === 1) {
+		homeId = [...this.switchIdToHomeId.values()][0];
+	}
+
+	if (!homeId) {
+		return primaryControllerId > 0 ? [primaryControllerId] : [];
+	}
+
+	const controllers = [...this.switchIdToHomeId.entries()]
+		.filter(([, candidateHomeId]) => candidateHomeId === homeId)
+		.map(([controllerId]) => controllerId)
+		.filter((controllerId) => controllerId > 0);
+
+	const ordered = [
+		preferred,
+		primaryControllerId > 0 ? primaryControllerId : undefined,
+		...controllers,
+	].filter((controllerId): controllerId is number => controllerId !== undefined);
+
+	const candidates = [...new Set(ordered)];
+
+	this.log.debug(
+		'[Cync TCP] controller resolution: device=%s home=%s primary=0x%s preferred=%s candidates=%s knownControllers=%s',
+		deviceId,
+		homeId,
+		primaryControllerId.toString(16).padStart(8, '0'),
+		preferred === undefined ? 'none' : `0x${preferred.toString(16).padStart(8, '0')}`,
+		candidates.map((controllerId) => `0x${controllerId.toString(16).padStart(8, '0')}`).join(', '),
+		[...this.switchIdToHomeId.entries()]
+			.map(([controllerId, controllerHomeId]) => `0x${controllerId.toString(16).padStart(8, '0')}=>${controllerHomeId}`)
+			.join(', '),
+	);
+
+	return candidates;
+}
 	// Reliable Controller Sender: Retries LAN packets through alternate controllers until state confirmation
 	// Centralizes controller failover so power, brightness, color temperature, and RGB commands use the same resilient routing.
 	private async sendWithControllerRetry(


### PR DESCRIPTION
BT-only bulbs come back from the cloud with switchID=0, which doesn't exist in switchIdToHomeId. Previously this caused getControllerCandidates to return only the (invalid) primaryControllerId, so commands never reached the bulb. Fall back to locating the home via the device's mesh membership and route through any Wi-Fi controller in that home.