### PR TITLE
fix: strip composite switchID suffix before storing as uint32 controller ID

### DIFF
--- a/src/cync/config-client.ts
+++ b/src/cync/config-client.ts
@@ -85,7 +85,12 @@ export interface CyncDevice {
 	mac?: string;
 	sn?: string;
 	switch_id?: string;
+	/** uint32 LAN controller ID, derived from raw_switch_id when the REST API returns a composite value */
 	switch_controller?: number | string;
+	/** Original switchID from the Cync REST API — may be a composite value encoding a device index */
+	raw_switch_id?: number;
+	/** Trailing device index encoded in raw_switch_id when it exceeds uint32 range (e.g. 1850364131001 → 1) */
+	switch_index?: number;
 	mesh_id?: number | string;
 
 	[key: string]: unknown;

--- a/src/cync/cync-client.ts
+++ b/src/cync/cync-client.ts
@@ -702,17 +702,15 @@ export class CyncClient {
 							meshIndex = (mod % 1000) + Math.floor(mod / 1000) * 256;
 						}
 
-						// Controller ID used by LAN packets (HA's switch_controller).
 						// The Cync REST API may return switchID as a composite value that
 						// encodes a device index in the trailing 3 digits
-						// (e.g. 1850364131001 → controller 1850364131, index 001).
-						// The TCP protocol encodes controller IDs as 4-byte unsigned integers,
-						// so strip the suffix when the raw value exceeds uint32 range.
+						// (e.g. 1850364131001 → controller 1850364131, index 1).
+						// rawSwitchId is preserved for accessory identity, API correlation, and logs.
+						// controllerId is the uint32 value used for LAN packet writes (writeUInt32BE).
 						const rawSwitchId = d.switchID as number | undefined;
-						const switchController =
-							rawSwitchId !== undefined && rawSwitchId > 0xffffffff
-								? Math.floor(rawSwitchId / 1000)
-								: rawSwitchId;
+						const isComposite = rawSwitchId !== undefined && rawSwitchId > 0xffffffff;
+						const controllerId = isComposite ? Math.floor(rawSwitchId! / 1000) : rawSwitchId;
+						const switchIndex = isComposite ? rawSwitchId! % 1000 : undefined;
 
 						// Use deviceID first, then wifiMac (stripped), then a mesh-based fallback.
 						const id =
@@ -728,13 +726,13 @@ export class CyncClient {
 							homeDevices[meshIndex] = deviceIdStr;
 						}
 
-						// Mirror HA's switchID_to_homeID + home_controllers
-						if (switchController !== undefined && Number.isFinite(switchController) && switchController > 0) {
-							if (!this.switchIdToHomeId[switchController]) {
-								this.switchIdToHomeId[switchController] = homeId;
+						// Mirror HA's switchID_to_homeID + home_controllers (keyed by uint32 controllerId)
+						if (controllerId !== undefined && Number.isFinite(controllerId) && controllerId > 0) {
+							if (!this.switchIdToHomeId[controllerId]) {
+								this.switchIdToHomeId[controllerId] = homeId;
 							}
-							if (!homeControllers.includes(switchController)) {
-								homeControllers.push(switchController);
+							if (!homeControllers.includes(controllerId)) {
+								homeControllers.push(controllerId);
 							}
 						}
 
@@ -745,7 +743,9 @@ export class CyncClient {
 							device_id: deviceIdStr,
 							mac: wifiMac,
 							mesh_id: meshIndex,
-							switch_controller: switchController,
+							switch_controller: controllerId,
+							raw_switch_id: rawSwitchId,
+							...(switchIndex !== undefined && { switch_index: switchIndex }),
 							raw: d,
 						});
 					}

--- a/src/cync/cync-client.ts
+++ b/src/cync/cync-client.ts
@@ -702,8 +702,17 @@ export class CyncClient {
 							meshIndex = (mod % 1000) + Math.floor(mod / 1000) * 256;
 						}
 
-						// Controller ID used by LAN packets (HA's switch_controller)
-						const switchController = d.switchID as number | undefined;
+						// Controller ID used by LAN packets (HA's switch_controller).
+						// The Cync REST API may return switchID as a composite value that
+						// encodes a device index in the trailing 3 digits
+						// (e.g. 1850364131001 → controller 1850364131, index 001).
+						// The TCP protocol encodes controller IDs as 4-byte unsigned integers,
+						// so strip the suffix when the raw value exceeds uint32 range.
+						const rawSwitchId = d.switchID as number | undefined;
+						const switchController =
+							rawSwitchId !== undefined && rawSwitchId > 0xffffffff
+								? Math.floor(rawSwitchId / 1000)
+								: rawSwitchId;
 
 						// Use deviceID first, then wifiMac (stripped), then a mesh-based fallback.
 						const id =


### PR DESCRIPTION
## Summary

`v0.3.3` introduced `requestMeshState` which calls `buildControllerPing` and `buildMeshInfoRequest`. Both write `controllerId` into a 4-byte buffer with `writeUInt32BE`, but the controller IDs flowing into `requestMeshState` come from `switchIdToHomeId` keys — which are populated directly from the raw `switchID` field of the Cync REST API.

On some devices the Cync REST API returns `switchID` as a 13-digit composite value that encodes a device index in the trailing 3 digits (e.g. `1850364131001` → controller `1850364131`, index `001`). This exceeds the uint32 maximum of `4294967295`, causing `writeUInt32BE` to throw a `RangeError` and crash the child bridge process on every startup.

## Crash

```
RangeError: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 1_850_364_131_001
    at TcpClient.buildControllerPing (src/cync/tcp-client.ts:822:15)
    at TcpClient.requestMeshState (src/cync/tcp-client.ts:851:24)
```

## Fix

Normalize `switchID` at the point of extraction in `loadConfiguration` (before it is stored in `switchIdToHomeId`, `homeControllers`, or `switch_controller`). When the raw value exceeds `0xFFFFFFFF`, strip the trailing 3-digit device index with `Math.floor(rawSwitchId / 1000)`. This restores a valid 4-byte controller ID and fixes the crash for both `requestMeshState` and the existing `buildPowerPacket`/`buildComboPacket` paths which would hit the same overflow when a user first toggles a device.

The 13-digit pattern is consistent across both affected devices in testing: `1558035658001` → `1558035658` and `1850364131001` → `1850364131`, both of which fit within uint32 range and match the controller ID already used in the internal accessory UUID (e.g. `cync-1850364131-1850364131001`).

## Test

Confirmed: plugin starts cleanly and loads both accessories without crashing. Observed previously: crash loop every ~7 seconds.