### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.4.1 — Maintenance Sweep
+
+**Release Date:** 2026-05-30
+
+### Changed
+- Reduced routine LAN device update logging from info to debug.
+- Kept device classification behavior centralized in `device-classifier.ts` while simplifying catalog metadata to descriptive model information.
+
+### Fixed
+- Removed unused accessory scaffolding, TCP helper state, LAN update bridge code, and obsolete catalog classification metadata.
+- Corrected package lockfile version metadata to match the published package version.
+
+### Notes
+- No device support or configuration changes are included in this release.
+- Unknown or partially supported devices continue to use the existing classifier fallback behavior.
+
 # v0.4.0 — Capability Classifier & Fan Support
 
 **Release Date:** 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## v0.4.1 — Maintenance Sweep
 
-**Release Date:** 2026-05-30
+**Release Date:** 2026-05-29
 
 ### Changed
-- Reduced routine LAN device update logging from info to debug.
+- Reduced routine LAN device update logging from **info** to **debug**.
 - Kept device classification behavior centralized in `device-classifier.ts` while simplifying catalog metadata to descriptive model information.
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "homebridge-cync-app",
-	"version": "0.1.7",
+	"version": "0.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "homebridge-cync-app",
-			"version": "0.1.7",
+			"version": "0.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@homebridge/plugin-ui-utils": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "homebridge-cync-app",
 	"displayName": "Homebridge Cync App",
 	"type": "module",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"private": false,
 	"description": "Homebridge plugin that integrates your GE Cync account (via the Cync app/API) and exposes all supported devices: plugs, lights, switches, etc",
 	"author": "Dustin Newell",
@@ -30,8 +30,8 @@
 		"platform": "CyncAppPlatform"
 	},
 	"funding": {
-		"type" : "paypal",
-		"url" : "https://paypal.me/DustinNewell"
+		"type": "paypal",
+		"url": "https://paypal.me/DustinNewell"
 	},
 	"engines": {
 		"node": "^20.18.0 || ^22.10.0 || ^24.0.0",


### PR DESCRIPTION
## Summary

Prepares the `v0.4.1` maintenance release after PR #19.

## Changes

- Bumps package metadata from `0.4.0` to `0.4.1`.
- Corrects root package version metadata in `package-lock.json`.
- Adds the `v0.4.1 — Maintenance Sweep` changelog entry.
- Leaves README unchanged because setup, supported devices, troubleshooting, badges, and project status did not change.

## Draft GitHub release notes

```md
## Summary

This maintenance release removes unused scaffolding and dead code after the v0.4.0 classifier refactor. Device classification behavior is unchanged: classification remains centralized in `device-classifier.ts`, while the device catalog now serves as descriptive model metadata.

## Changed
- Reduced routine LAN device update logging from info to debug.
- Simplified device catalog metadata by removing obsolete classification defaults.

## Fixed
- Removed unused accessory scaffolding, TCP helper state, and LAN update bridge code.
- Corrected package lockfile version metadata to match the package version.

## Verification
- `npm run lint`
- `npm run build`
```

## Issue / PR comments

No issue-closing comments are needed. No `Fixes #...` reference applies to this release-prep commit.

## Suggested squash commit message

```text
Prepare v0.4.1 release

Co-authored-by: OpenAI Codex <codex@openai.com>
```

## Verification

- `npm run lint`
- `npm run build`