### PR TITLE
LAN sync improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Show selections are stored by Cync device ID, so renaming a device does not rese
 
 Some Cync devices expose both RGB color and color temperature controls. HomeKit may present these differently depending on the accessory category and Home app behavior.
 
+Cync white presets are exposed to HomeKit as color temperature values, not as RGB colors. The Cync app presents presets such as **Cool White**, **Daylight**, **Sunlight**, **Natural White**, **Early Morning**, **Sunrise**, and **Warm White** as a discrete ladder. HomeKit represents the same idea as a continuous color-temperature slider using mired values, where lower mired values are cooler and higher mired values are warmer.
+
+Because of that, the Home app may not visually match the Cync preset list one-for-one. For example, **Natural White** may appear near the center of HomeKit's temperature gradient, while **Cool White** and **Warm White** should appear near the cool and warm ends respectively. This is expected: HomeKit is showing the calibrated temperature position, while the Cync app is showing named presets.
+
+The Home app's **Swatch** tab can look visually similar to Cync's white presets, but swatches are RGB color selections. Choosing a swatch may put the device into RGB color mode instead of tunable-white color-temperature mode. For best white-temperature behavior, use the Temperature control in HomeKit or the white preset list in the Cync app.
+
+If a Cync white preset maps to an unexpected HomeKit position, enable debug logging and include the relevant `compact state 0x43` or `mesh state record` lines when opening an issue. These lines include the Cync tone byte and the HomeKit mired value used by the plugin.
+
 ### Outlets and Switches
 
 Certain Cync device types are exposed as outlets instead of generic switches to improve HomeKit behavior and Siri integration.

--- a/src/cync/cync-light-accessory.ts
+++ b/src/cync/cync-light-accessory.ts
@@ -576,6 +576,9 @@ export function configureCyncLightAccessory(
 			// Treat CT as "white mode" (not RGB color mode)
 			cyncMeta.colorTemperature = mired;
 			cyncMeta.colorActive = false;
+			cyncMeta.hue = 0;
+			cyncMeta.saturation = 0;
+			cyncMeta.rgb = { r: 255, g: 255, b: 255 };
 
 			const brightness =
 				typeof cyncMeta.brightness === 'number' ? cyncMeta.brightness : 100;

--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -18,6 +18,10 @@ type TransportMode = 'tls_strict' | 'tls_relaxed' | 'tcp';
 
 const POST_COMMAND_MESH_REFRESH_DELAY_MS = 750;
 const POWER_STATE_CONFIRM_TIMEOUT_MS = 10_000;
+const CTC_MIN_MIRED = 153;
+const CTC_MAX_MIRED = 500;
+const CYNC_CT_WARM_TONE = 24;
+const CYNC_CT_COOL_TONE = 100;
 
 function clampNumber(n: number, min: number, max: number): number {
 	return Math.min(max, Math.max(min, n));
@@ -34,11 +38,28 @@ function hkBrightnessToPct100Byte(hkBrightness: number): number {
 	return clampNumber(hk, 1, 100);
 }
 
-function scaleToByte(value: number, inMin: number, inMax: number, invert: boolean): number {
-	const v = clampNumber(value, inMin, inMax);
-	const t = (v - inMin) / (inMax - inMin); // 0..1
-	const u = invert ? (1 - t) : t;
-	return clampNumber(Math.round(u * 255), 0, 255);
+function colorToneByteToMired(colorTone: number): number {
+	const tone = clampNumber(Math.round(colorTone), 0, 255);
+	const t = clampNumber(
+		(tone - CYNC_CT_WARM_TONE) / (CYNC_CT_COOL_TONE - CYNC_CT_WARM_TONE),
+		0,
+		1,
+	);
+	return clampNumber(
+		Math.round(CTC_MAX_MIRED - (t * (CTC_MAX_MIRED - CTC_MIN_MIRED))),
+		CTC_MIN_MIRED,
+		CTC_MAX_MIRED,
+	);
+}
+
+function miredToColorToneByte(mired: number, ctMinMired: number, ctMaxMired: number): number {
+	const clampedMired = clampNumber(Math.round(mired), ctMinMired, ctMaxMired);
+	const coolness = (ctMaxMired - clampedMired) / (ctMaxMired - ctMinMired);
+	return clampNumber(
+		Math.round(CYNC_CT_WARM_TONE + (coolness * (CYNC_CT_COOL_TONE - CYNC_CT_WARM_TONE))),
+		CYNC_CT_WARM_TONE,
+		CYNC_CT_COOL_TONE,
+	);
 }
 // TCP Hex Formatter: Makes packet dumps easier to compare byte-by-byte
 // Formats buffers as spaced hex so working and failing packets can be visually diffed.
@@ -57,6 +78,7 @@ export type LanDeviceUpdate = {
 	brightnessPct?: number;
 	lastNonZeroBrightnessPct?: number;
 	rgb?: { r: number; g: number; b: number };
+	colorTemperatureMired?: number;
 };
 
 export type LanDeviceUpdateListener = (update: LanDeviceUpdate) => void;
@@ -334,6 +356,67 @@ export class TcpClient {
 		);
 
 		return { controllerId, deviceId, on, brightnessPct, lastNonZeroBrightnessPct };
+	}
+
+	private parseCompactStateFrame43(frame: Buffer): LanDeviceUpdate | null {
+		if (frame.length < 26) {
+			return null;
+		}
+
+		const controllerId = frame.readUInt32BE(0);
+		const homeId = this.switchIdToHomeId.get(controllerId);
+		if (!homeId) {
+			return null;
+		}
+
+		const devices = this.homeDevices[homeId];
+		if (!devices || devices.length === 0) {
+			return null;
+		}
+
+		if (frame[9] !== 0x10) {
+			return null;
+		}
+
+		const deviceIndex = frame[10];
+		const deviceId = deviceIndex < devices.length ? devices[deviceIndex] : undefined;
+		if (!deviceId) {
+			return null;
+		}
+
+		const on = frame[11] > 0;
+		const levelByte = frame[12];
+		const colorTone = frame[13];
+		const brightnessPct = on ? clampNumber(levelByte, 1, 100) : 0;
+		const lastNonZeroBrightnessPct =
+			levelByte > 0 ? clampNumber(levelByte, 1, 100) : undefined;
+		const rgb = colorTone === 0xfe
+			? { r: frame[14], g: frame[15], b: frame[16] }
+			: undefined;
+		const colorTemperatureMired = colorTone !== 0xfe
+			? colorToneByteToMired(colorTone)
+			: undefined;
+
+		this.log.debug(
+			'[Cync TCP] compact state 0x43: device=%s index=%d on=%s level=%d tone=0x%s mired=%s rgb=%o prefix=%s',
+			deviceId,
+			deviceIndex,
+			String(on),
+			levelByte,
+			colorTone.toString(16).padStart(2, '0'),
+			colorTemperatureMired === undefined ? 'none' : String(colorTemperatureMired),
+			rgb,
+			formatHexPrefix(frame),
+		);
+
+		return {
+			deviceId,
+			on,
+			brightnessPct,
+			lastNonZeroBrightnessPct,
+			rgb,
+			colorTemperatureMired,
+		};
 	}
 
 
@@ -1503,14 +1586,18 @@ export class TcpClient {
 			const rgb = colorTone === 0xfe
 				? { r: rec[20], g: rec[21], b: rec[22] }
 				: undefined;
+			const colorTemperatureMired = colorTone !== 0xfe
+				? colorToneByteToMired(colorTone)
+				: undefined;
 
 			this.log.debug(
-				'[Cync TCP] mesh state record: device=%s index=%d on=%s level=%d ct=%d rgb=%o',
+				'[Cync TCP] mesh state record: device=%s index=%d on=%s level=%d ct=%d mired=%s rgb=%o',
 				deviceId,
 				deviceIndex,
 				String(on),
 				levelByte,
 				colorTone,
+				colorTemperatureMired === undefined ? 'none' : String(colorTemperatureMired),
 				rgb,
 			);
 
@@ -1520,6 +1607,7 @@ export class TcpClient {
 				brightnessPct,
 				lastNonZeroBrightnessPct,
 				rgb,
+				colorTemperatureMired,
 			});
 			this.confirmPendingPowerCommand(deviceId, on, 'mesh state');
 		}
@@ -1681,8 +1769,7 @@ export class TcpClient {
 			const on = hkBrightness > 0;
 			const level = hkBrightnessToPct100Byte(hkBrightness);
 
-			const invertTone = params.invertTone === true;
-			const tone = scaleToByte(mired, ctMinMired, ctMaxMired, invertTone);
+			const tone = miredToColorToneByte(mired, ctMinMired, ctMaxMired);
 
 			await this.sendWithControllerRetry(
 				deviceId,
@@ -2038,7 +2125,14 @@ export class TcpClient {
 		}
 
 		if (type === 0x43) {
-			this.logUnparsedFrame(type, frame, 'compact event/status frame');
+			const compactParsed = this.parseCompactStateFrame43(frame);
+			if (compactParsed) {
+				payload = compactParsed;
+				this.emitLanDeviceUpdate(compactParsed);
+				this.confirmPendingPowerCommand(compactParsed.deviceId, compactParsed.on, 'compact LAN update');
+			} else {
+				this.logUnparsedFrame(type, frame, 'compact event/status frame');
+			}
 		}
 
 		if ((type === 0x73 || type === 0x83) && frame.length >= 14) {

--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -403,11 +403,18 @@ export class TcpClient {
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
 
-			// Fire and forget; ensureConnected() logs failures already
-			void this.ensureConnected().catch((err: unknown) => {
-				this.log.debug('[Cync TCP] Reconnect attempt failed: %s', String(err));
-				this.scheduleReconnect('retry');
-			});
+			void (async () => {
+				try {
+					const connected = await this.ensureConnected();
+					if (!connected) {
+						this.log.debug('[Cync TCP] Reconnect attempt did not establish a socket.');
+						this.scheduleReconnect('retry');
+					}
+				} catch (err: unknown) {
+					this.log.debug('[Cync TCP] Reconnect attempt failed: %s', String(err));
+					this.scheduleReconnect('retry');
+				}
+			})();
 		}, delayMs);
 	}
 
@@ -1735,7 +1742,7 @@ export class TcpClient {
 			this.processIncoming();
 		});
 
-		socket.on('close', () => {
+		socket.on('close', (hadError) => {
 			this.log.warn('[Cync TCP] Socket closed.');
 			this.resetCommandSessionState('establishSocket');
 
@@ -1749,12 +1756,7 @@ export class TcpClient {
 				this.socket = null;
 			}
 
-			this.reconnectAttempt = 0;
-
-			if (this.reconnectTimer) {
-				clearTimeout(this.reconnectTimer);
-				this.reconnectTimer = null;
-			}
+			this.scheduleReconnect(hadError ? 'socket closed after error' : 'socket closed');
 		});
 
 		socket.on('error', (err) => {

--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -16,6 +16,8 @@ export type RawFrameListener = (frame: Buffer) => void;
 
 type TransportMode = 'tls_strict' | 'tls_relaxed' | 'tcp';
 
+const POST_COMMAND_MESH_REFRESH_DELAY_MS = 750;
+
 function clampNumber(n: number, min: number, max: number): number {
 	return Math.min(max, Math.max(min, n));
 }
@@ -98,6 +100,8 @@ export class TcpClient {
 	private rawFrameListeners: RawFrameListener[] = [];
 	private controllerToDevice = new Map<number, string>();
 	private reconnectTimer: NodeJS.Timeout | null = null;
+	private meshStateRefreshTimer: NodeJS.Timeout | null = null;
+	private meshStateRefreshInFlight = false;
 	private reconnectAttempt = 0;
 	private connectInFlight: Promise<void> | null = null;
 	private shuttingDown = false;
@@ -418,6 +422,50 @@ export class TcpClient {
 		}, delayMs);
 	}
 
+	private scheduleMeshStateRefresh(
+		reason: string,
+		delayMs = POST_COMMAND_MESH_REFRESH_DELAY_MS,
+	): void {
+		if (this.shuttingDown) {
+			this.log.debug('[Cync TCP] Not scheduling mesh-state refresh (shutting down): %s', reason);
+			return;
+		}
+
+		if (this.meshStateRefreshTimer) {
+			clearTimeout(this.meshStateRefreshTimer);
+		}
+
+		this.log.debug('[Cync TCP] Scheduling mesh-state refresh in %dms (%s)', delayMs, reason);
+
+		this.meshStateRefreshTimer = setTimeout(() => {
+			this.meshStateRefreshTimer = null;
+			void this.refreshMeshState(reason);
+		}, delayMs);
+	}
+
+	private async refreshMeshState(reason: string): Promise<void> {
+		if (this.meshStateRefreshInFlight) {
+			this.log.debug('[Cync TCP] Mesh-state refresh already in flight; rescheduling (%s)', reason);
+			this.scheduleMeshStateRefresh(`in-flight: ${reason}`);
+			return;
+		}
+
+		if (!this.socket || this.socket.destroyed) {
+			this.log.debug('[Cync TCP] Mesh-state refresh skipped; socket unavailable (%s)', reason);
+			return;
+		}
+
+		this.meshStateRefreshInFlight = true;
+		try {
+			this.log.debug('[Cync TCP] Refreshing mesh state (%s)', reason);
+			await this.requestMeshState();
+		} catch (err) {
+			this.log.debug('[Cync TCP] Mesh-state refresh failed (%s): %s', reason, String(err));
+		} finally {
+			this.meshStateRefreshInFlight = false;
+		}
+	}
+
 	private async establishSocket(): Promise<void> {
 		const host = 'cm.gelighting.com';
 		const portTLS = 23779;
@@ -722,6 +770,8 @@ export class TcpClient {
 					deviceId,
 					candidateControllerId.toString(16).padStart(8, '0'),
 				);
+
+				this.scheduleMeshStateRefresh(`${logLabel} command accepted`);
 
 				return;
 			}
@@ -1393,6 +1443,12 @@ export class TcpClient {
 			this.reconnectTimer = null;
 		}
 		this.reconnectAttempt = 0;
+
+		if (this.meshStateRefreshTimer) {
+			clearTimeout(this.meshStateRefreshTimer);
+			this.meshStateRefreshTimer = null;
+		}
+		this.meshStateRefreshInFlight = false;
 
 		if (this.heartbeatTimer) {
 			clearInterval(this.heartbeatTimer);

--- a/src/cync/tcp-client.ts
+++ b/src/cync/tcp-client.ts
@@ -17,6 +17,7 @@ export type RawFrameListener = (frame: Buffer) => void;
 type TransportMode = 'tls_strict' | 'tls_relaxed' | 'tcp';
 
 const POST_COMMAND_MESH_REFRESH_DELAY_MS = 750;
+const POWER_STATE_CONFIRM_TIMEOUT_MS = 10_000;
 
 function clampNumber(n: number, min: number, max: number): number {
 	return Math.min(max, Math.max(min, n));
@@ -45,6 +46,11 @@ function formatHex(buffer: Buffer): string {
 	return buffer.toString('hex').match(/.{1,2}/g)?.join(' ') ?? '';
 }
 
+function formatHexPrefix(buffer: Buffer, maxBytes = 32): string {
+	const prefix = formatHex(buffer.subarray(0, maxBytes));
+	return buffer.length > maxBytes ? `${prefix} ...` : prefix;
+}
+
 export type LanDeviceUpdate = {
 	deviceId: string;
 	on: boolean;
@@ -62,6 +68,7 @@ export class TcpClient {
 		const pendingCount = this.pendingPowerCommands.size;
 
 		for (const pending of this.pendingPowerCommands.values()) {
+			clearTimeout(pending.confirmationTimer);
 			pending.resolve?.(false);
 		}
 
@@ -105,6 +112,7 @@ export class TcpClient {
 	private reconnectAttempt = 0;
 	private connectInFlight: Promise<void> | null = null;
 	private shuttingDown = false;
+	private readonly unparsedFrameLogCounts = new Map<string, number>();
 	private readonly lanDeviceUpdateListeners: LanDeviceUpdateListener[] = [];
 	private pendingPowerCommands = new Map<string, {
 		deviceId: string;
@@ -114,6 +122,7 @@ export class TcpClient {
 		seq: number;
 		sentAt: number;
 		packetHex: string;
+		confirmationTimer: NodeJS.Timeout;
 		resolve?: (confirmed: boolean) => void;
 	}>();
 	public onLanDeviceUpdate(listener: LanDeviceUpdateListener): void {
@@ -126,6 +135,63 @@ export class TcpClient {
 			} catch (err) {
 				this.log.error('[Cync TCP] lan device update listener threw: %s', String(err));
 			}
+		}
+	}
+
+	private logUnparsedFrame(type: number, frame: Buffer, reason: string): void {
+		const subtype = frame.length >= 14 ? frame[13] : undefined;
+		const controllerId = frame.length >= 4 ? frame.readUInt32BE(0) : undefined;
+		const seq = frame.length >= 6 ? frame.readUInt16BE(4) : undefined;
+		const key = [
+			type.toString(16),
+			subtype === undefined ? 'none' : subtype.toString(16),
+			frame.length,
+			reason,
+		].join(':');
+
+		const count = (this.unparsedFrameLogCounts.get(key) ?? 0) + 1;
+		this.unparsedFrameLogCounts.set(key, count);
+
+		if (count !== 1 && count % 25 !== 0) {
+			return;
+		}
+
+		this.log.debug(
+			'[Cync TCP] Unparsed frame (%s): type=0x%s subtype=%s len=%d controller=%s seq=%s seen=%d prefix=%s',
+			reason,
+			type.toString(16).padStart(2, '0'),
+			subtype === undefined ? 'n/a' : `0x${subtype.toString(16).padStart(2, '0')}`,
+			frame.length,
+			controllerId === undefined ? 'n/a' : `0x${controllerId.toString(16).padStart(8, '0')}`,
+			seq === undefined ? 'n/a' : String(seq),
+			count,
+			formatHexPrefix(frame),
+		);
+	}
+
+	private confirmPendingPowerCommand(
+		deviceId: string,
+		on: boolean,
+		source: string,
+	): void {
+		for (const [key, pending] of this.pendingPowerCommands.entries()) {
+			if (pending.deviceId !== deviceId || pending.on !== on) {
+				continue;
+			}
+
+			clearTimeout(pending.confirmationTimer);
+			this.preferredControllerByDevice.set(deviceId, pending.controllerId);
+			pending.resolve?.(true);
+			this.pendingPowerCommands.delete(key);
+
+			this.log.info(
+				'[Cync TCP] Power state confirmed by %s: device=%s on=%s controller=0x%s ageMs=%d',
+				source,
+				deviceId,
+				String(on),
+				pending.controllerId.toString(16).padStart(8, '0'),
+				Date.now() - pending.sentAt,
+			);
 		}
 	}
 
@@ -443,6 +509,10 @@ export class TcpClient {
 		}, delayMs);
 	}
 
+	public requestMeshStateRefresh(reason: string, delayMs = 0): void {
+		this.scheduleMeshStateRefresh(reason, delayMs);
+	}
+
 	private async refreshMeshState(reason: string): Promise<void> {
 		if (this.meshStateRefreshInFlight) {
 			this.log.debug('[Cync TCP] Mesh-state refresh already in flight; rescheduling (%s)', reason);
@@ -736,7 +806,27 @@ export class TcpClient {
 			const packet = packetBuilder(candidateControllerId, seq);
 
 			const rejected = await new Promise<boolean>((resolve) => {
-				this.pendingPowerCommands.set(`${candidateControllerId}:${seq}`, {
+				const pendingKey = `${candidateControllerId}:${seq}`;
+				const confirmationTimer = setTimeout(() => {
+					const pending = this.pendingPowerCommands.get(pendingKey);
+					if (!pending) {
+						return;
+					}
+
+					this.pendingPowerCommands.delete(pendingKey);
+
+					this.log.warn(
+						'[Cync TCP] %s state not confirmed within %dms: device=%s expectedOn=%s controller=0x%s seq=%d',
+						logLabel,
+						POWER_STATE_CONFIRM_TIMEOUT_MS,
+						deviceId,
+						String(expectedOn),
+						candidateControllerId.toString(16).padStart(8, '0'),
+						seq,
+					);
+				}, POWER_STATE_CONFIRM_TIMEOUT_MS);
+
+				this.pendingPowerCommands.set(pendingKey, {
 					deviceId,
 					on: expectedOn,
 					controllerId: candidateControllerId,
@@ -744,6 +834,7 @@ export class TcpClient {
 					seq,
 					sentAt: Date.now(),
 					packetHex: packet.toString('hex'),
+					confirmationTimer,
 					resolve: (confirmed) => resolve(!confirmed),
 				});
 
@@ -765,7 +856,7 @@ export class TcpClient {
 				this.preferredControllerByDevice.set(deviceId, candidateControllerId);
 
 				this.log.debug(
-					'[Cync TCP] %s command accepted/no immediate rejection: device=%s controller=0x%s',
+					'[Cync TCP] %s command transport accepted; awaiting state confirmation: device=%s controller=0x%s',
 					logLabel,
 					deviceId,
 					candidateControllerId.toString(16).padStart(8, '0'),
@@ -777,7 +868,7 @@ export class TcpClient {
 			}
 		}
 		this.log.warn(
-			'[Cync TCP] %s command not confirmed for device=%s on=%s after trying %d controller(s).',
+			'[Cync TCP] %s command transport rejected for device=%s on=%s after trying %d controller(s).',
 			logLabel,
 			deviceId,
 			String(expectedOn),
@@ -1430,6 +1521,7 @@ export class TcpClient {
 				lastNonZeroBrightnessPct,
 				rgb,
 			});
+			this.confirmPendingPowerCommand(deviceId, on, 'mesh state');
 		}
 	}
 
@@ -1902,8 +1994,11 @@ export class TcpClient {
 					pending?.packetHex ?? 'unknown',
 				);
 
-				pending?.resolve?.(false);
-				this.pendingPowerCommands.delete(pendingKey);
+				if (pending) {
+					clearTimeout(pending.confirmationTimer);
+					pending.resolve?.(false);
+					this.pendingPowerCommands.delete(pendingKey);
+				}
 				this.handleIncomingFrame(body, type);
 			} else {
 				this.handleIncomingFrame(body, type);
@@ -1943,18 +2038,7 @@ export class TcpClient {
 		}
 
 		if (type === 0x43) {
-			this.log.debug(
-				'[Cync TCP] compact frame 0x43: len=%d body=%s b0=%d b1=%d b2=%d b3=%d b4=%d b5=%d b6=%d',
-				frame.length,
-				formatHex(frame),
-				frame[0],
-				frame[1],
-				frame[2],
-				frame[3],
-				frame[4],
-				frame[5],
-				frame[6],
-			);
+			this.logUnparsedFrame(type, frame, 'compact event/status frame');
 		}
 
 		if ((type === 0x73 || type === 0x83) && frame.length >= 14) {
@@ -1984,20 +2068,7 @@ export class TcpClient {
 					lastNonZeroBrightnessPct: lanParsed.lastNonZeroBrightnessPct,
 					rgb,
 				});
-				for (const [key, pending] of this.pendingPowerCommands.entries()) {
-					if (pending.deviceId === devId && pending.on === lanParsed.on) {
-						this.preferredControllerByDevice.set(devId, pending.controllerId);
-						pending.resolve?.(true);
-						this.pendingPowerCommands.delete(key);
-
-						this.log.info(
-							'[Cync TCP] Power command confirmed: device=%s on=%s controller=0x%s',
-							devId,
-							String(lanParsed.on),
-							pending.controllerId.toString(16).padStart(8, '0'),
-						);
-					}
-				}
+				this.confirmPendingPowerCommand(devId, lanParsed.on, 'LAN update');
 
 			} else if (type === 0x83) {
 				// Fallback to legacy controller-level parsing only for 0x83
@@ -2008,8 +2079,22 @@ export class TcpClient {
 						...parsed,
 						deviceId,
 					};
+					if (!deviceId) {
+						this.logUnparsedFrame(type, frame, 'legacy switch update without device mapping');
+					}
 				}
 			}
+		}
+
+		if (
+			payload === frame &&
+			type !== 0x18 &&
+			type !== 0x43 &&
+			type !== 0x78 &&
+			type !== 0x7b &&
+			type !== 0xab
+		) {
+			this.logUnparsedFrame(type, frame, 'no parsed device update');
 		}
 
 		if (this.deviceUpdateCb) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -110,6 +110,18 @@ function promoteCapabilitiesFromLan(
 		changed = true;
 	}
 
+	if (
+		current.isLight &&
+		typeof update.colorTemperatureMired === 'number' &&
+		Number.isFinite(update.colorTemperatureMired)
+	) {
+		if (!current.supportsCt) {
+			current.supportsCt = true;
+			current.source = 'lan';
+			changed = true;
+		}
+	}
+
 	return changed;
 }
 
@@ -613,6 +625,8 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 			// Cache (optional, but helps keep internal state consistent)
 			ctx.cync.hue = hsv.h;
 			ctx.cync.saturation = hsv.s;
+			ctx.cync.rgb = update.rgb;
+			ctx.cync.colorActive = true;
 
 			if (lightService.testCharacteristic(Characteristic.Hue)) {
 				lightService.updateCharacteristic(Characteristic.Hue, hsv.h);
@@ -629,6 +643,37 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 				update.rgb.b,
 				Math.round(hsv.h),
 				Math.round(hsv.s),
+				update.deviceId,
+			);
+		}
+		// ----- Color Temperature -----
+		if (
+			lightService &&
+			typeof update.colorTemperatureMired === 'number' &&
+			Number.isFinite(update.colorTemperatureMired)
+		) {
+			const mired = Math.max(153, Math.min(500, Math.round(update.colorTemperatureMired)));
+
+			ctx.cync.colorTemperature = mired;
+			ctx.cync.colorActive = false;
+			ctx.cync.hue = 0;
+			ctx.cync.saturation = 0;
+			ctx.cync.rgb = { r: 255, g: 255, b: 255 };
+
+			if (lightService.testCharacteristic(Characteristic.ColorTemperature)) {
+				lightService.updateCharacteristic(Characteristic.ColorTemperature, mired);
+			}
+			if (lightService.testCharacteristic(Characteristic.Hue)) {
+				lightService.updateCharacteristic(Characteristic.Hue, 0);
+			}
+			if (lightService.testCharacteristic(Characteristic.Saturation)) {
+				lightService.updateCharacteristic(Characteristic.Saturation, 0);
+			}
+
+			this.log.debug(
+				'Cync: LAN update -> %s colorTemperature=%d mired (deviceId=%s)',
+				accessory.displayName,
+				mired,
 				update.deviceId,
 			);
 		}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -49,6 +49,8 @@ const toCyncLogger = (log: Logger): CyncLogger => ({
 	error: log.error.bind(log),
 });
 
+const PERIODIC_MESH_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 type CyncShowKind =
 	| 'built-in-light'
 	| 'built-in-music'
@@ -127,11 +129,11 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 	private cloudConfig: CyncCloudConfig | null = null;
 	private readonly deviceIdToAccessory = new Map<string, PlatformAccessory>();
 	private readonly deviceLastSeen = new Map<string, number>();
-	private readonly devicePollTimers = new Map<string, NodeJS.Timeout>();
+	private readonly polledDeviceIds = new Set<string>();
+	private meshPollTimer: NodeJS.Timeout | null = null;
 	private showAccessoryRegistrationDisabled = false;
 
 	private readonly offlineTimeoutMs = 30 * 60 * 1000;
-	private readonly pollIntervalMs = 60_000; // 60 seconds
 
 	private setMainAccessoryOnForDevice(deviceId: string, on: boolean): void {
 		const accessory = this.deviceIdToAccessory.get(deviceId);
@@ -437,19 +439,24 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 	}
 
 	private startPollingDevice(deviceId: string): void {
-		const existing = this.devicePollTimers.get(deviceId);
-		if (existing) {
-			clearInterval(existing);
+		this.polledDeviceIds.add(deviceId);
+
+		if (this.meshPollTimer) {
+			return;
 		}
 
-		const timer = setInterval(() => {
-			// Optional future hook:
-			// - Call a "getDeviceState" or similar on tcpClient/client
-			// - On success, call this.markDeviceSeen(deviceId)
-			// - On failure, optionally log or mark offline
-		}, this.pollIntervalMs);
+		this.log.debug(
+			'Cync: starting periodic mesh refresh every %dms',
+			PERIODIC_MESH_REFRESH_INTERVAL_MS,
+		);
 
-		this.devicePollTimers.set(deviceId, timer);
+		this.meshPollTimer = setInterval(() => {
+			if (this.polledDeviceIds.size === 0) {
+				return;
+			}
+
+			this.tcpClient.requestMeshStateRefresh('periodic platform refresh');
+		}, PERIODIC_MESH_REFRESH_INTERVAL_MS);
 	}
 
 	private handleLanUpdate(update: LanDeviceUpdate): void {
@@ -502,13 +509,19 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 
 		// ----- On/off -----
 		if (typeof update.on === 'boolean') {
+			const previousOn = ctx.cync.on;
 			ctx.cync.on = update.on;
 
-			this.log.info(
-				'Cync: LAN update -> %s is now %s (deviceId=%s)',
+			const logLanPowerUpdate = previousOn === update.on
+				? this.log.debug.bind(this.log)
+				: this.log.info.bind(this.log);
+
+			logLanPowerUpdate(
+				'Cync: LAN update -> %s is now %s (deviceId=%s)%s',
 				accessory.displayName,
 				update.on ? 'ON' : 'OFF',
 				update.deviceId,
+				previousOn === update.on ? ' (already cached)' : '',
 			);
 
 			if (lightService || outletService || switchService) {
@@ -675,6 +688,13 @@ export class CyncAppPlatform implements DynamicPlatformPlugin {
 		this.api.on('didFinishLaunching', () => {
 			this.log.info(PLATFORM_NAME, 'didFinishLaunching');
 			void this.loadCync();
+		});
+		this.api.on('shutdown', () => {
+			if (this.meshPollTimer) {
+				clearInterval(this.meshPollTimer);
+				this.meshPollTimer = null;
+			}
+			this.polledDeviceIds.clear();
 		});
 		this.accessoryEnv = {
 		  log: this.log,


### PR DESCRIPTION
## Summary
- Map Cync white tones to HomeKit mired values and update light state caches for color temperature updates.
- Refresh mesh state after power commands and on a periodic interval so LAN updates stay in sync.
- Improve confirmation handling, logging, and fallback parsing for compact and mesh state frames.
- Document how Cync white presets relate to HomeKit temperature controls in the README.

## Testing
- Not run (not requested)
- Added and adjusted state handling paths for LAN/mesh parsing and accessory updates to cover white presets and confirmation flow.